### PR TITLE
Update variants_remap.json

### DIFF
--- a/variants_remap.json
+++ b/variants_remap.json
@@ -19,6 +19,7 @@
     "frdm_kl27z": "KL27Z",
     "frdm_kl43z": "KL43Z",
     "frdm_kl46z": "KL46Z",
+    "frdm_kl82z": "KL82Z",
     "frdm_k64f": "K64F",
     "frdm_k82f": "K82F",
     "IBMEthernetKit": "K64F",


### PR DESCRIPTION
FRDM_KL82Z was not in the variant list, so the target mapping failed. With this change, the mbed framework allows to build for FRDM_KL82Z