### PR TITLE
Load .mbedignore from project root directory

### DIFF
--- a/pio_mbed_adapter.py
+++ b/pio_mbed_adapter.py
@@ -29,6 +29,9 @@ from tools.utils import generate_update_filename
 from pio_mock_notifier import PlatformioFakeNotifier
 from pio_resources_fixed_path import MbedResourcesFixedPath
 
+from pio_mbedignore_loader import PioMbedignoreLoader
+
+
 # A handy global as PlatformIO supports only GCC toolchain
 TOOLCHAIN_NAME = "GCC_ARM"
 # Possible profiles: debug, develop, release
@@ -193,8 +196,15 @@ class PlatformioMbedAdapter(object):
         #         error_msg = "The library src folder doesn't exist:%s", src_path
         #         raise Exception(error_msg)
 
-
-        self.resources = MbedResourcesFixedPath(self.framework_path, self.notify).scan_with_toolchain(
+        mbedignore_path_in_project_root_dir = os.path.join(
+            backup_cwd, '.mbedignore')
+        mbedignore_patterns_from_project_root_dir = PioMbedignoreLoader(
+            mbedignore_path_in_project_root_dir).collect_ignore_patterns()
+        mbed_resources_fixed_path = MbedResourcesFixedPath(
+            self.framework_path, self.notify)
+        mbed_resources_fixed_path.add_ignore_patterns(
+            '.', '.', mbedignore_patterns_from_project_root_dir)
+        self.resources = mbed_resources_fixed_path.scan_with_toolchain(
             self.src_paths, self.toolchain, dependencies_paths,
             inc_dirs=inc_dirs)
 

--- a/pio_mbedignore_loader.py
+++ b/pio_mbedignore_loader.py
@@ -47,6 +47,7 @@ class PioMbedignoreLoader(MbedIgnoreSet):
         self._collect_patterns_from_mbedignore_file_and_save_them()
         self._remove_mbed_framework_prefix_from_patterns()
         self._remove_first_directory_name_from_patterns()
+        self._remove_match_all_patterns()
         self._is_patterns_collected = True
         return self._ignore_patterns
 
@@ -72,3 +73,10 @@ class PioMbedignoreLoader(MbedIgnoreSet):
             self._ignore_patterns)
         self._ignore_patterns = list(
             paths_without_first_directory_name_iterator)
+
+    def _remove_match_all_patterns(self):
+        paths_without_match_all_patterns_iterator = filter(
+            lambda p: p != '*',
+            self._ignore_patterns)
+        self._ignore_patterns = list(
+            paths_without_match_all_patterns_iterator)

--- a/pio_mbedignore_loader.py
+++ b/pio_mbedignore_loader.py
@@ -1,0 +1,74 @@
+# Copyright 2019-present PlatformIO <contact@platformio.org>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from tools.resources import MbedIgnoreSet
+
+
+class PioMbedignoreLoader(MbedIgnoreSet):
+    """Loads ignore patterns from .mbedignore file
+
+    It takes the path to the `.mbedignore` file in the constructor.
+    The collect_ignore_patterns() will return the list of the patterns
+    from the file. For each pattern the 'mbed-os/' or 'framework-mbed/' prefix
+    will be removed if specified. Since originial MbedIgnoreSet computes
+    relative paths starting from the first parent directory,
+    the parent directory name will be removed, so e.g. paterrns:
+
+        mbed-os/features/cellular/*
+        framework-mbed/features/cellular/*
+        features/cellular/*
+
+    will be turned to:
+
+        cellular/*
+
+    """
+
+    def __init__(self, mbedignore_path):
+        self._mbedignore_path = mbedignore_path
+        self._is_patterns_collected = False
+        super().__init__()
+
+    def collect_ignore_patterns(self):
+        if self._is_patterns_collected:
+            return self._ignore_patterns
+
+        self._collect_patterns_from_mbedignore_file_and_save_them()
+        self._remove_mbed_framework_prefix_from_patterns()
+        self._remove_first_directory_name_from_patterns()
+        self._is_patterns_collected = True
+        return self._ignore_patterns
+
+    def _collect_patterns_from_mbedignore_file_and_save_them(self):
+        try:
+            self.add_mbedignore('.', self._mbedignore_path)
+            print('Loaded .mbedignore patterns from: {}'.format(
+                self._mbedignore_path))
+        except FileNotFoundError:
+            print('No .mbedignore found under {}'.format(
+                self._mbedignore_path))
+
+    def _remove_mbed_framework_prefix_from_patterns(self):
+        paths_without_mbed_framework_prefix_iterator = map(
+            lambda p: p.replace('mbed-os/', '').replace('framework-mbed/', ''),
+            self._ignore_patterns)
+        self._ignore_patterns = list(
+            paths_without_mbed_framework_prefix_iterator)
+
+    def _remove_first_directory_name_from_patterns(self):
+        paths_without_first_directory_name_iterator = map(
+            lambda p: p[p.find('/')+1:],
+            self._ignore_patterns)
+        self._ignore_patterns = list(
+            paths_without_first_directory_name_iterator)


### PR DESCRIPTION
# Description

If `.mbedignore` is present in the root directory of the project, it will be applied to the build.

The `.mbedignore` supports [official file format](https://os.mbed.com/docs/mbed-os/v6.14/program-setup/build-rules.html#mbedignore). Moreover, the `.mbedignore` files used within a pure `mbed` project (without `pio`), can be used without changes as well.

Additionally, to prevent from confusion, other patterns prefixes are supported too:

```
mbed-os/features/cellular/*
framework-mbed/features/cellular/*
features/cellular/*
``` 

are equivalent and will result in excluding:

```
features/cellular/*
```
The following commit messages explain more details:
* https://github.com/platformio/builder-framework-mbed/commit/8ca976f30b6857844b0bf33287503d3370e9b324 
* https://github.com/platformio/builder-framework-mbed/commit/68f470bafd278925abd66fa433dcc2023a9352b1

# Background

This solution came out from [this forum post](https://community.platformio.org/t/eager-to-implement-handling-of-mbedignore-within-pio/23735/2). Maximilian Gerhardt suggested to use `self.ignore_dirs` to implement that feature. Unfortunately, there is a [bug in MBED's build API](https://github.com/ARMmbed/mbed-os/issues/15125).

