### PR TITLE
Upgrade dependencies to fix Python 3.10 compatibility

### DIFF
--- a/install_python_deps.py
+++ b/install_python_deps.py
@@ -32,14 +32,14 @@ def exec_cmd(*args, **kwargs):
 def build_packages():
 
     packages = (
-        "intelhex>=1.3,<=2.3.0",
-        "jinja2>=2.10.1,<2.11",
+        "intelhex==2.3.0",
+        "jinja2==3.1.2",
         "pyelftools==0.25",
-        "beautifulsoup4>=4,<=4.6.3",
-        "future==0.17.1",
-        "prettytable==0.7.2",
-        "jsonschema==2.6.0",
-        "six==1.12.0"
+        "beautifulsoup4==4.11.1",
+        "future==0.18.1",
+        "prettytable==3.3.0",
+        "jsonschema==4.14.0",
+        "six==1.16.0"
     )
 
     target_dir = join(


### PR DESCRIPTION
As reported in #27, using this framework is currently broken with Python 3.10 due to old dependencies being used. Upgrading the dependencies fixes the issue.

Technically the only required change is setting `jinja2==3.1.2`, but I figured we might as well upgrade everything. Unsure why some dependencies were specified by version ranges, as this script always installs the dependencies in an isolated directory, so there should never be any need for using older versions to manage conflicts.

This PR also supersedes #28.